### PR TITLE
generalize script with cli options, improved header decoding/joining, message-id filepath fix

### DIFF
--- a/mbox2html.py
+++ b/mbox2html.py
@@ -46,7 +46,10 @@ def get_header_text(msg, item, default='utf-8'):
             except:
                 header_section = text
         else:
-            header_section = text.decode(charset or default)
+            try:
+                header_section = text.decode(charset or default)
+            except:
+                header_section = text.decode(default)
         if header_section:
             header_sections.append(header_section)
     return ' '.join(header_sections)

--- a/mbox2html.py
+++ b/mbox2html.py
@@ -81,9 +81,13 @@ def parse_email( msg ):
         if ( subtype == 'alternative' ):
             # TODO: Can this contain non-text?
             types = [m.get_content_type() for m in payload]
+            if args.mode == 'plain':
+                type_list = ['text/plain']
+            else:
+                type_list = ['text/html', 'text/plain']
             return [{
                 'name': msg.get_filename(),
-                'content': payload_get_type( payload, types, ['text/html', 'text/plain'] ),
+                'content': payload_get_type( payload, types, type_list ),
                 'type': 'text',
             }]
         else:

--- a/mbox2html.py
+++ b/mbox2html.py
@@ -283,7 +283,7 @@ def write_message_tree( file, msg_ids, threads, messages ):
         file.write( '<li>%s: %s</li>' % (
             html.escape( format_date( msg ) ),
             '<a href="%s">%s</a>' % (
-                urllib.parse.quote( mid + '.html' ),
+                urllib.parse.quote( mid.replace('/','-') + '.html' ),
                 get_header_text( msg, 'subject' )
             )
         ) )
@@ -346,8 +346,8 @@ if __name__ == '__main__':
     # Writes email html files
     for key, msg in messages.items():
         msg_id = msg.get( 'message-id' )
-        body_path = os.path.join( outdir, msg_id + '.html' )
-        attachment_path = os.path.join( outdir, msg_id )
+        body_path = os.path.join( outdir, msg_id.replace('/','-') + '.html' )
+        attachment_path = os.path.join( outdir, msg_id.replace('/','-') )
 
         # Deletes all previous files (if they exist) for easier append-age later
         try:

--- a/mbox2html.py
+++ b/mbox2html.py
@@ -47,7 +47,7 @@ def get_header_text(msg, item, default='utf-8'):
                 header_section = text
         else:
             try:
-                header_section = text.decode(charset or default)
+                header_section = text.decode(charset)
             except:
                 header_section = text.decode(default)
         if header_section:

--- a/mbox2html.py
+++ b/mbox2html.py
@@ -20,14 +20,17 @@ def flatten( l ):
             yield i
 
 # Puts date into consistent format
-def format_date( msg ):
-    date = msg.get( 'date' )
+def format_date( msg, listing=False):
+    msg_date = msg.get( 'date' )
     try:
-        return email.utils.format_datetime(
-            email.utils.parsedate_to_datetime( date )
-        )
+        date = email.utils.parsedate_to_datetime( msg_date )
+        if listing:
+            date_format = "%Y %d. %B %A"
+            return date.strftime(date_format)
+        else:
+            return email.utils.format_datetime(date)
     except ValueError:
-        return date
+        return msg_date
 
 # Helps extracting tricky header info (at times needed for Subject and From)
 def get_header_text(msg, item, default='utf-8'):
@@ -285,7 +288,7 @@ def write_message_tree( file, msg_ids, threads, messages ):
     for mid in msg_ids:
         msg = messages[mid]
         file.write( '<li>%s: %s</li>' % (
-            html.escape( format_date( msg ) ),
+            html.escape( format_date( msg, listing=True ) ),
             '<a href="%s">%s</a>' % (
                 urllib.parse.quote( mid.replace('/','-') + '.html' ),
                 get_header_text( msg, 'subject' )

--- a/mbox2html.py
+++ b/mbox2html.py
@@ -60,7 +60,7 @@ def get_payload_text( msg ):
     payload = msg.get_payload( decode=True )
     if ( payload is None ): return ''
     charset = msg.get_charset() or chardet.detect( payload )['encoding']
-    content = payload.decode( charset )
+    content = payload.decode( charset or 'utf-8' )
     if ( subtype == 'plain' ):
         return html.escape( content ).replace( '\n', '<br>' )
     else:


### PR DESCRIPTION
as promised in https://github.com/davisdude/mbox2html/issues/2, here are my changes - the commits were redone to be sorted by most- to least useful for you to cherry-pick, starting with the 'add cli options' and the changed 'header decoding'. Replacing slashes helped with github message-ids that are formed according to their issue threads http paths.

The bottom commits get more subjective: an option only to extract text/plain message parts and lastly to control date formatting for the index list differently than in the message view.

You kept to a style of spacing the parantheses. It wasn't deliberate to not have minded this for newly written lines, I can redo the branch if you're strict on this, it only got apparent to me when finalizing the branch push. If you prefer individual PRs for each change instead of cherry-picking, I'd happily do so for those you want to merge.

I did test against randomly assorted mailing lists, personal mails and newsletters. The header decoding really seemed improved. There are still some message-ids that can go missing that I haven't tracked down the reason for yet, but this should be as before.